### PR TITLE
Fix(오정민): 마이페이지 테마 리스트가 필터에 맞게 랜더링 되도록 수정

### DIFF
--- a/src/components/mypage/FollowUserList.tsx
+++ b/src/components/mypage/FollowUserList.tsx
@@ -1,5 +1,6 @@
 import useInfiniteScroll from '@/hooks/useInfiniteScroll'
 import useInfiniteFollowUser from '@/hooks/user/useInfiniteFollowUser'
+import { Spinner } from 'flowbite-react'
 import FollowUser from './FollowUser'
 
 interface FollowUserListProps {
@@ -11,6 +12,7 @@ interface FollowUserListProps {
 
 export default function FollowUserList({ type, userId, name, title }: FollowUserListProps) {
   const {
+    isPending,
     isError,
     data: followUserList,
     fetchNextPage,
@@ -39,26 +41,26 @@ export default function FollowUserList({ type, userId, name, title }: FollowUser
       <h3 className="mb-5 text-xl font-semibold leading-7 md:mb-8 xl:text-2xl">
         {name}님{title}하는 유저
       </h3>
-      {!isError ? (
-        allFollowUsers && allFollowUsers.length > 0 ? (
-          <>
-            <div className="flex max-h-[456px] flex-col content-center items-start gap-5 overflow-auto scrollbar-hide">
-              {allFollowUsers.map(followUser => (
-                <FollowUser
-                  key={followUser.id}
-                  followUserData={type === 'follower' ? followUser.follower! : followUser.followee!}
-                />
-              ))}
-            </div>
-            <div ref={targetRef} className="mb-4" />
-          </>
-        ) : (
-          <p className="font-normal text-brand-gray-dark">아직 없습니다</p>
-        )
-      ) : (
-        <p>
+      {isPending && <Spinner aria-label="로딩 중..." size="xl" />}
+      {isError && (
+        <p className="font-normal text-brand-gray-dark">
           {name}님{title}하는 유저 리스트 불러오기에 실패하였습니다. 다시 시도해주세요.
         </p>
+      )}
+      {allFollowUsers && allFollowUsers.length > 0 ? (
+        <>
+          <div className="flex max-h-[456px] flex-col content-center items-start gap-5 overflow-auto scrollbar-hide">
+            {allFollowUsers.map(followUser => (
+              <FollowUser
+                key={followUser.id}
+                followUserData={type === 'follower' ? followUser.follower! : followUser.followee!}
+              />
+            ))}
+          </div>
+          <div ref={targetRef} className="mb-4" />
+        </>
+      ) : (
+        <p className="font-normal text-brand-gray-dark">아직 없습니다</p>
       )}
     </div>
   )

--- a/src/components/mypage/ProductCardList.tsx
+++ b/src/components/mypage/ProductCardList.tsx
@@ -66,9 +66,6 @@ export default function ProductCardList({ data }: ProductCardListProps) {
     refetchProductList()
   }, [queryClient, refetchProductList, activeMenu])
 
-  if (isPending) return <Spinner aria-label="로딩 중..." size="xl" />
-  if (isError) return <p>테마 리스트 불러오기에 실패하였습니다. 다시 시도해주세요.</p>
-
   return (
     <section>
       <div className="mb-[30px] flex items-center justify-normal gap-10">
@@ -82,6 +79,10 @@ export default function ProductCardList({ data }: ProductCardListProps) {
           </button>
         ))}
       </div>
+      {isPending && <Spinner aria-label="로딩 중..." size="xl" />}
+      {isError && (
+        <p className="font-normal text-brand-gray-dark">테마 리스트 불러오기에 실패하였습니다. 다시 시도해주세요.</p>
+      )}
       {allProducts && allProducts.length > 0 ? (
         <>
           <div className="grid grid-cols-2 gap-[15px] xl:grid-cols-3 xl:gap-5">

--- a/src/components/mypage/ProductCardList.tsx
+++ b/src/components/mypage/ProductCardList.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Spinner } from 'flowbite-react'
 import { UserTypes } from '@/dtos/UserDto'
 import useInfiniteUserProduct from '@/hooks/user/useInfiniteUserProduct'
@@ -41,11 +41,13 @@ export default function ProductCardList({ data }: ProductCardListProps) {
 
   const allProducts = productList?.pages.flatMap(page => page.list)
 
-  const handleProductMenuClicked = (selectedId: number) => {
+  const handleProductMenuClicked = useCallback((selectedId: number) => {
     setActiveMenu(selectedId)
-  }
+  }, [])
 
-  refetchProductList()
+  useEffect(() => {
+    refetchProductList()
+  }, [activeMenu, refetchProductList])
 
   if (isPending) return <Spinner aria-label="로딩 중..." size="xl" />
   if (isError) return <p>테마 리스트 불러오기에 실패하였습니다. 다시 시도해주세요.</p>

--- a/src/components/mypage/Profile.tsx
+++ b/src/components/mypage/Profile.tsx
@@ -49,7 +49,6 @@ export default function Profile({ data: userData, refetchUserInfo = () => {} }: 
   const toggleFollowModal = useCallback(() => setIsFollowModalOpen(prev => !prev), [])
   const toggleEditProfileModal = useCallback(() => setIsEditProfileModalOpen(prev => !prev), [])
 
-  /** 페이지를 이동하면 열려 있던 모달을 닫는 함수 */
   useEffect(() => {
     const handleRouteChange = () => {
       if (isFollowModalOpen) {


### PR DESCRIPTION
## ✏️ 작업 내용 요약

> 이번 PR에서 작업한 내용을 요약해주세요

- 유저 및 마이페이지 테마 리스트가 선택한 필터에 맞게 랜더링 되도록 수정
  - 쿼리 키를 아예 remove하여 캐싱 정보를 모두 지우고
  - 다시 새로운 정보로 refetch()하도록 함
  - [참고 블로그](https://junvelee.tistory.com/132)

## 📝 PR 타입

> 하나 이상의 PR 타입을 선택해주세요

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 디자인 수정
- [ ] 코드 리팩토링
- [x] 버그 수정
- [ ] 기타: 직접작성

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

-

## 🏷️ 연관된 이슈 번호

> ex) 이슈 번호

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/794cfcc3-f73f-4b3e-b809-561a1340ba9f

